### PR TITLE
Adds `package_id` to created Solr documents

### DIFF
--- a/src/main/java/gov/nasa/pds/citool/search/DocWriter.java
+++ b/src/main/java/gov/nasa/pds/citool/search/DocWriter.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.commons.lang.StringEscapeUtils;
 
@@ -44,6 +45,7 @@ public class DocWriter
 	public void write(Map<String, List<String>> fields) throws Exception
 	{
 		writer.write("<doc>\n");
+		writer.write("<field name=\"package_id\">" + UUID.randomUUID().toString() + "</field>\n");
 		
 		for(Map.Entry<String, List<String>> field: fields.entrySet())
 		{


### PR DESCRIPTION
This commit resolves NASA-PDS/registry-legacy-solr#96 but also suppresses the numerous stack traces from Solr miscommunication. The end result is a Solr `.xml` file which can be loaded with `registry-mgr-legacy`.

## ⚙️ Test Data and/or Report
```console
$ catalog --mode ingest --doc-config $CATALOG_HOME/search-conf/defaults/ --output-dir ~/Downloads/solr --report-file /tmp/report.log --target ~/Documents/Clients/JPL/PDS/Legacy/data/JNOJNC_0024/ 
…
$ echo $?
0
$ ls -l ~/Downloads/solr
-rw-r--r--  1 kelly  staff  130462 Sep 26 13:36 usa_nasa_pds_jnojnc_0xxx__jnojnc_0024.solr.xml
```

## ♻️ Related Issues

- NASA-PDS/registry-legacy-solr#96 
