### PR TITLE
Upgrade to latest solr 9.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <dependency>
       <groupId>gov.nasa.pds</groupId>
       <artifactId>pds3-product-tools</artifactId>
-      <version>4.0.1</version>
+      <version>4.3.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
-      <version>8.11.2</version>
+      <version>9.3.0</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->
Resolves NASA-PDS/registry-legacy-solr#94 

Note: The upgrade appears to have broke viewDataset.jsp
<img width="1042" alt="Screenshot 2023-10-04 at 5 45 01 PM" src="https://github.com/NASA-PDS/registry-pds3-catalog/assets/33492486/d0970088-d73e-46ab-8a2d-3d6c3b3649bb">

