### PR TITLE
`LICENSE.txt` → `LICENSE.md`

### DIFF
--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -59,7 +59,7 @@
 
   <files>
     <file>
-      <source>LICENSE.txt</source>
+      <source>LICENSE.md</source>
       <outputDirectory>/</outputDirectory>
       <fileMode>644</fileMode>
       <lineEnding>unix</lineEnding>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -60,7 +60,7 @@
 
   <files>
     <file>
-      <source>LICENSE.txt</source>
+      <source>LICENSE.md</source>
       <outputDirectory>/</outputDirectory>
       <fileMode>644</fileMode>
       <lineEnding>crlf</lineEnding>

--- a/src/site/xdoc/install/index.xml.vm
+++ b/src/site/xdoc/install/index.xml.vm
@@ -89,7 +89,7 @@ or
           <p>A README file directing the user to the available documentation for the project.
           </p>
         </li>
-        <li><b>LICENSE.txt</b><br/>
+        <li><b>LICENSE.md</b><br/>
           <p>The copyright notice from the <a href="http://www.caltech.edu/" target="_blank">California Institute of Technology</a> detailing the restrictions regarding the use and distribution of this software. Although the license is strictly worded, the software has been classified as Technology and Software Publicly Available (TSPA) and is available for <i>anyone</i> to download and use.
           </p>
         </li>


### PR DESCRIPTION
## 🗒️ Summary

In c6e1e6bb7a9ba0d01b284a3b4b2e9022bb69ded5 and 5a6a41e749c6edc972041d60938991c480d83029 the `LICENSE.txt` became `LICENSE.md`. This updates the website docs and the assembly files to follow suit.

## ⚙️ Test Data and/or Report

Before:
```console
$ mvn clean package
…
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.2-beta-5:single (bin-release) on project catalog: Failed to create assembly: File to filter not found: /Users/kelly/Documents/Clients/JPL/PDS/Legacy/src/registry-pds3-catalog/LICENSE.txt (No such file or directory) -> [Help 1]
```

After:
```console
$ mvn clean package
…
[INFO] BUILD SUCCESS
…
```

## ♻️ Related Issues

N/A