### PR TITLE
Update assembly .xml files for renamed commands

### DIFF
--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -22,7 +22,7 @@
       <directory>src/main/resources/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <includes>
-        <include>catalog</include>
+        <include>catalog-legacy</include>
       </includes>
       <fileMode>755</fileMode>
       <lineEnding>unix</lineEnding>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -22,8 +22,8 @@
       <directory>src/main/resources/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <includes>
-        <include>catalog</include>
-        <include>catalog.bat</include>
+        <include>catalog-legacy</include>
+        <include>catalog-legacy.bat</include>
       </includes>
       <fileMode>755</fileMode>
       <lineEnding>keep</lineEnding>


### PR DESCRIPTION
I'd missed these when renaming the command files, so they are not included in the application zip/tar when assembled.